### PR TITLE
Initialize control loop time step globally

### DIFF
--- a/dob_controller/include/dob_controller/dob_controller.h
+++ b/dob_controller/include/dob_controller/dob_controller.h
@@ -25,6 +25,8 @@ class DisturbanceObserverCtrl
 
     double a0_x, a0_y, a0_z, a1_x, a1_y, a1_z, tau_x, tau_y, tau_z;
     double dhat_max, dhat_min;
+    double control_dt_;
+    double status_dt_;
  
     std::vector<Eigen::Vector2d> q_, p_;
 


### PR DESCRIPTION
Previously the time step parameter was defined in several different places

This PR initialized the `control_dt` variable globally so that it is more explicitly defined.