### PR TITLE
Add mav_comm as dependency of rosisntall

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -7,3 +7,6 @@
 - git:
     local-name: mavros_controllers
     uri: https://github.com/Jaeyoung-Lim/mavros_controllers.git
+- git:
+    local-name: mav_comm
+    uri: https://github.com/ethz-asl/mav_comm.git


### PR DESCRIPTION
**Problem Description**
This commit adds mav_comm in the rosinstall dependency tree in order to fix the ros noetic build tests